### PR TITLE
enable configurable preview using django-pagedown

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,23 @@ from .celery import app as celery_app
 ```
 celery -A project_name worker -l INFO
 ```
+
+## Other Settings
+
+### Use markdown editor with preview (django-pagedown)
+
+Django-pagedown editor is automatically enabled if you have `pagedown` in your `INSTALLED_APPS`
+
+In order not to break the layout and add an i18n tweak to the text "Preview", you'll need to include the following settings:
+
+```
+# Pagedown Editor
+PAGEDOWN_WIDGET_CSS = ('pagedown/demo/browser/demo.css', "css/editor.css",)
+PAGEDOWN_WIDGET_TEMPLATE = 'niji/widgets/pagedown.html'
+```
+
+### Show site name in html title
+
+```
+NIJI_SITE_NAME = "xxx"  # This will add "-xxx" to html title
+```

--- a/forms.py
+++ b/forms.py
@@ -1,12 +1,23 @@
 # -*- coding: utf-8 -*-
 from django.forms import ModelForm
+from django.conf import settings
 from crispy_forms.layout import Submit
 from crispy_forms.helper import FormHelper
-from .models import Topic, Appendix, ForumAvatar
+from .models import Topic, Appendix, ForumAvatar, Post
 from django.utils.translation import ugettext as _
+
+if 'pagedown' in settings.INSTALLED_APPS:
+    use_pagedown = True
+    from django import forms
+    from pagedown.widgets import PagedownWidget
+else:
+    use_pagedown = False
 
 
 class TopicForm(ModelForm):
+
+    if use_pagedown:
+        content_raw = forms.CharField(label=_('Content'), widget=PagedownWidget())
 
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop('user', None)
@@ -33,6 +44,9 @@ class TopicForm(ModelForm):
 
 
 class TopicEditForm(ModelForm):
+
+    if use_pagedown:
+        content_raw = forms.CharField(label=_('Content'), widget=PagedownWidget())
 
     def __init__(self, *args, **kwargs):
         super(TopicEditForm, self).__init__(*args, **kwargs)
@@ -90,6 +104,35 @@ class ForumAvatarForm(ModelForm):
     def save(self, commit=True):
         inst = super(ForumAvatarForm, self).save(commit=False)
         inst.user = self.user
+        if commit:
+            inst.save()
+            self.save_m2m()
+        return inst
+
+
+class ReplyForm(ModelForm):
+
+    if use_pagedown:
+        content_raw = forms.CharField(label='', widget=PagedownWidget())
+
+    def __init__(self, *args, **kwargs):
+        self.user = kwargs.pop('user', None)
+        self.topic_id = kwargs.pop('topic_id', None)
+        super(ReplyForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.add_input(Submit('submit', _('Submit')))
+
+    class Meta:
+        model = Post
+        fields = ('content_raw',)
+        labels = {
+            'content_raw': '',
+        }
+
+    def save(self, commit=True):
+        inst = super(ReplyForm, self).save(commit=False)
+        inst.user = self.user
+        inst.topic_id = self.topic_id
         if commit:
             inst.save()
             self.save_m2m()

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-28 12:55-0400\n"
+"POT-Creation-Date: 2016-07-18 03:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,48 +18,48 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: forms.py:15 forms.py:40 forms.py:56 forms.py:80 templates/niji/login.html:23
-#: templates/niji/reg.html.py:31 templates/niji/topic.html:105
-msgid "Submit"
-msgstr "提交"
-
-#: forms.py:21 forms.py:46 forms.py:62
+#: forms.py:20 forms.py:32 forms.py:49 forms.py:60 forms.py:76
 msgid "Content"
 msgstr "内容"
 
-#: forms.py:22
+#: forms.py:26 forms.py:54 forms.py:70 forms.py:94 forms.py:123
+#: templates/niji/login.html:23 templates/niji/reg.html:31
+msgid "Submit"
+msgstr "提交"
+
+#: forms.py:33
 msgid "Node"
 msgstr "节点"
 
-#: forms.py:23
+#: forms.py:34
 msgid "Title"
 msgstr "标题"
 
-#: forms.py:86
+#: forms.py:100
 msgid "Avatar Image"
 msgstr "头像图片"
 
-#: forms.py:87
+#: forms.py:101
 msgid "Always Use Gravatar"
 msgstr "始终使用 Gravatar"
 
-#: templates/niji/base.html:35 templates/niji/base.html.py:37
+#: templates/niji/base.html:36 templates/niji/base.html:38
 msgid "Search"
 msgstr "搜索"
 
-#: templates/niji/includes/list.html:39 templates/niji/user_info.html.py:35
+#: templates/niji/includes/list.html:39 templates/niji/user_info.html:35
 msgid "Last Replied"
 msgstr "最后回复"
 
-#: templates/niji/login.html:16 templates/niji/reg.html.py:16
+#: templates/niji/login.html:16 templates/niji/reg.html:16
 msgid "Username"
 msgstr "用户名"
 
-#: templates/niji/login.html:20 templates/niji/reg.html.py:24
+#: templates/niji/login.html:20 templates/niji/reg.html:24
 msgid "Password"
 msgstr "密码"
 
-#: templates/niji/notifications.html:9 views.py:207 views.py:225
+#: templates/niji/notifications.html:9 views.py:252 views.py:276
 msgid "Notifications"
 msgstr "提醒"
 
@@ -117,51 +117,47 @@ msgstr "Email"
 msgid "Repeat Password"
 msgstr "重复密码"
 
-#: templates/niji/topic.html:24
+#: templates/niji/topic.html:25
 #, python-format
 msgid "viewed %(view_count)s times"
 msgstr "%(view_count)s次浏览"
 
-#: templates/niji/topic.html:37
+#: templates/niji/topic.html:38
 #, python-format
 msgid "appendix %(number)s"
 msgstr "第%(number)s条附言"
 
-#: templates/niji/topic.html:47
+#: templates/niji/topic.html:48
 msgid "Edit"
 msgstr "编辑"
 
-#: templates/niji/topic.html:49
+#: templates/niji/topic.html:50
 msgid "Append"
 msgstr "添加附言"
 
-#: templates/niji/topic.html:56
+#: templates/niji/topic.html:57
 #, python-format
 msgid "%(reply_count)s Reply"
 msgid_plural "%(reply_count)s Replies"
 msgstr[0] "%(reply_count)s条回复"
 
-#: templates/niji/topic.html:58
+#: templates/niji/topic.html:59
 msgid "No Replies"
 msgstr "暂无回复"
 
-#: templates/niji/topic.html:82
+#: templates/niji/topic.html:83
 msgid "Reply"
 msgstr "回复"
 
-#: templates/niji/topic.html:87
+#: templates/niji/topic.html:88
 msgid "Be the first to reply!"
 msgstr "暂无回复"
 
-#: templates/niji/topic.html:95
+#: templates/niji/topic.html:96
 msgid "Leave a Reply"
 msgstr "添加回复"
 
-#: templates/niji/topic.html:103
-msgid "Markdown enabled"
-msgstr "可使用 Markdown"
-
-#: templates/niji/topic.html:111
+#: templates/niji/topic.html:106
 #, python-format
 msgid ""
 "\n"
@@ -204,7 +200,7 @@ msgstr ""
 msgid "Replied to"
 msgstr "回复"
 
-#: templates/niji/widgets/authenticated_user_panel.html:47 views.py:132
+#: templates/niji/widgets/authenticated_user_panel.html:47 views.py:177
 msgid "Create Topic"
 msgstr "创建主题"
 
@@ -239,78 +235,85 @@ msgstr "登出"
 msgid "Nodes"
 msgstr "节点"
 
+#: templates/niji/widgets/pagedown.html:9
+msgid "Preview"
+msgstr "预览"
+
 #: templates/niji/widgets/visitor_user_panel.html:9
 msgid "Log in"
 msgstr "登入"
 
-#: templates/niji/widgets/visitor_user_panel.html:12 views.py:260
+#: templates/niji/widgets/visitor_user_panel.html:12 views.py:311
 msgid "Reg"
 msgstr "注册"
 
-#: views.py:31
+#: views.py:37
 msgid "New Topics"
 msgstr "最新主题"
 
-#: views.py:32
+#: views.py:38
 msgid "Index"
 msgstr "首页"
 
-#: views.py:110
+#: views.py:155
 msgid "Search: "
 msgstr "搜索: "
 
-#: views.py:139
+#: views.py:184
 msgid "Editing is not allowed when topic has been replied"
 msgstr "主题被回复后不可编辑"
 
-#: views.py:141
+#: views.py:186
 msgid "You are not allowed to edit other's topic"
 msgstr "你不能编辑他人的主题"
 
-#: views.py:150
+#: views.py:195
 msgid "Edit Topic"
 msgstr "编辑主题"
 
-#: views.py:157
+#: views.py:202
 msgid "You are not allowed to append other's topic"
 msgstr "你不能给他人的主题添加附言"
 
-#: views.py:167
+#: views.py:212
 msgid "Create Appendix"
 msgstr "添加附言"
 
-#: views.py:199
+#: views.py:244
 msgid "Upload Avatar"
 msgstr "上传头像"
 
-#: views.py:231
+#: views.py:282
 msgid "Login"
 msgstr "登入"
 
-#: views.py:238
+#: views.py:289
 msgid "Username and password cannot be empty"
 msgstr "用户名和密码不能为空"
 
-#: views.py:242
+#: views.py:293
 msgid "User does not exist"
 msgstr "该用户不存在"
 
-#: views.py:250
+#: views.py:301
 msgid "User deactivated"
 msgstr "该用户被禁用"
 
-#: views.py:253
+#: views.py:304
 msgid "Incorrect password"
 msgstr "密码错误"
 
-#: views.py:269
+#: views.py:320
 msgid "User already exists"
 msgstr "用户已存在"
 
-#: views.py:272
+#: views.py:323
 msgid "Password does not match"
 msgstr "两次密码不匹配"
 
-#: views.py:275
+#: views.py:326
 msgid "Invalid Email"
 msgstr "邮箱格式不正确"
+
+#~ msgid "Markdown enabled"
+#~ msgstr "可使用 Markdown"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-cython
 mistune
 wheel>=0.24.0
 Django>=1.9

--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -1,0 +1,20 @@
+.wmd-panel
+{
+	margin-left: 0;
+	margin-right: 0;
+	width: 100%;
+}
+.wmd-input {
+    height: 300px;
+    width: 100%;
+    background-color: white;
+    border: solid 1px #cccccc;
+}
+.wmd-preview {
+    background-color: white;
+    border: solid 1px #cccccc;
+    padding: 10px;
+}
+.wmd-preview-title {
+    margin-top: 10px;
+}

--- a/templates/niji/topic.html
+++ b/templates/niji/topic.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load niji_tags %}
 {% load humanize %}
+{% load crispy_forms_tags %}
 
 {% block left %}
     <div class="panel panel-default">
@@ -95,14 +96,8 @@
         <div class="panel-heading">{% trans "Leave a Reply"%}</div>
         <div class="panel-body">
             {% if request.user.is_authenticated %}
-                <form action="{% url 'niji:reply' pk=topic.pk %}" method="POST">
-                    {% csrf_token %}
-                    <div class="form-group">
-                        <label for="reply-content-input" class="hidden">Content</label>
-                        <textarea id="reply-content-input" name="content" class="form-control" rows="6"></textarea>
-                        <p class="help-block">{% trans "Markdown enabled" %}</p>
-                    </div>
-                    <button type="submit" class="btn btn-default">{% trans 'Submit' %}</button>
+                <form action="{% url 'niji:topic' pk=topic.pk %}" method="POST">
+                    {% crispy form %}
                 </form>
             {% else %}
                 <div class="alert alert-warning" role="alert">

--- a/templates/niji/widgets/pagedown.html
+++ b/templates/niji/widgets/pagedown.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+
+<div class="wmd-wrapper" id="{{ id }}-wmd-wrapper">
+    <div class="wmd-panel">
+        <div id="{{ id|safe }}_wmd_button_bar"></div>
+        <textarea{{ attrs|safe }}>{{ body }}</textarea>
+    </div>
+    {% if show_preview %}
+        <p class="wmd-preview-title"><small>{% trans 'Preview' %}:</small></p>
+        <div id="{{ id|safe }}_wmd_preview" class="wmd-panel wmd-preview"></div>
+    {% endif %}
+</div>

--- a/urls.py
+++ b/urls.py
@@ -11,7 +11,6 @@ urlpatterns = [
     url(r'^t/(?P<pk>\d+)/append/$', views.create_appendix, name='create_appendix'),
     url(r'^t/(?P<pk>\d+)/page/(?P<page>[0-9]+)/$', views.TopicView.as_view(), name='topic'),
     url(r'^t/(?P<pk>\d+)/$', views.TopicView.as_view(), name='topic'),
-    url(r'^t/(?P<pk>\d+)/reply', views.create_reply, name='reply'),
     url(r'^u/(?P<pk>\d+)/$', views.user_info, name='user_info'),
     url(r'^u/(?P<pk>\d+)/topics/page/(?P<page>[0-9]+)/$', views.UserTopics.as_view(), name='user_topics'),
     url(r'^u/(?P<pk>\d+)/topics/$', views.UserTopics.as_view(), name='user_topics'),


### PR DESCRIPTION
Use django-pagedown to enable editor preview and also provides a more easy-to-use editor.

Override some css to keep layout and styles consistent.

Override the default template to provide i18n to "Preview".

Also,  the editor is automatically enabled if "pagedown" is in "INSTALLED_APP"