### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#NIJI
+# NIJI
 
 [![Build Status](https://travis-ci.org/ericls/niji.svg?branch=master)](https://travis-ci.org/ericls/niji) [![Documentation Status](https://readthedocs.org/projects/django-niji/badge/?version=latest)](http://django-niji.readthedocs.io/en/latest/?badge=latest)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
